### PR TITLE
Custom allocator

### DIFF
--- a/include/Quadtree.h
+++ b/include/Quadtree.h
@@ -10,7 +10,13 @@
 namespace quadtree
 {
 
-template<typename T, typename GetBox, typename Equal = std::equal_to<T>, typename Float = float>
+template<
+    typename T,
+    typename GetBox,
+    typename Equal = std::equal_to<T>,
+    typename Float = float,
+    template <typename> class Allocator = std::allocator
+>
 class Quadtree
 {
     static_assert(std::is_convertible_v<std::invoke_result_t<GetBox, const T&>, Box<Float>>,
@@ -20,6 +26,9 @@ class Quadtree
     static_assert(std::is_arithmetic_v<Float>);
 
 public:
+    template <typename U>
+    using vector_type = std::vector< U, Allocator<U> >;
+
     Quadtree(const Box<Float>& box, const GetBox& getBox = GetBox(),
         const Equal& equal = Equal()) :
         mBox(box), mRoot(std::make_unique<Node>()), mGetBox(getBox), mEqual(equal)
@@ -37,16 +46,16 @@ public:
         remove(mRoot.get(), nullptr, mBox, value);
     }
 
-    std::vector<T> query(const Box<Float>& box) const
+    vector_type<T> query(const Box<Float>& box) const
     {
-        auto values = std::vector<T>();
+        auto values = vector_type<T>();
         query(mRoot.get(), mBox, box, values);
         return values;
     }
 
-    std::vector<std::pair<T, T>> findAllIntersections() const
+    vector_type<std::pair<T, T>> findAllIntersections() const
     {
-        auto intersections = std::vector<std::pair<T, T>>();
+        auto intersections = vector_type<std::pair<T, T>>();
         findAllIntersections(mRoot.get(), intersections);
         return intersections;
     }
@@ -58,7 +67,7 @@ private:
     struct Node
     {
         std::array<std::unique_ptr<Node>, 4> children;
-        std::vector<T> values;
+        vector_type<T> values;
     };
 
     Box<Float> mBox;
@@ -165,7 +174,7 @@ private:
         for (auto& child : node->children)
             child = std::make_unique<Node>();
         // Assign values to children
-        auto newValues = std::vector<T>(); // New values for this node
+        auto newValues = vector_type<T>(); // New values for this node
         for (const auto& value : node->values)
         {
             auto i = getQuadrant(box, mGetBox(value));
@@ -238,7 +247,7 @@ private:
         }
     }
 
-    void query(Node* node, const Box<Float>& box, const Box<Float>& queryBox, std::vector<T>& values) const
+    void query(Node* node, const Box<Float>& box, const Box<Float>& queryBox, vector_type<T>& values) const
     {
         assert(node != nullptr);
         assert(queryBox.intersects(box));
@@ -258,7 +267,7 @@ private:
         }
     }
 
-    void findAllIntersections(Node* node, std::vector<std::pair<T, T>>& intersections) const
+    void findAllIntersections(Node* node, vector_type<std::pair<T, T>>& intersections) const
     {
         // Find intersections between values stored in this node
         // Make sure to not report the same intersection twice
@@ -284,7 +293,7 @@ private:
         }
     }
 
-    void findIntersectionsInDescendants(Node* node, const T& value, std::vector<std::pair<T, T>>& intersections) const
+    void findIntersectionsInDescendants(Node* node, const T& value, vector_type<std::pair<T, T>>& intersections) const
     {
         // Test against the values stored in this node
         for (const auto& other : node->values)


### PR DESCRIPTION
Allow users to specify an allocator for the vector object used by the library. Also allow a functor to replace usage of std::make_unique with a custom version. Works with both C++14 and C++17.

This is the least intrusive change I could think of, but if you have suggestions I'm happy to make changes to this PR.